### PR TITLE
Added local-repository option.

### DIFF
--- a/lib/application.py
+++ b/lib/application.py
@@ -322,7 +322,9 @@ class Application:
         else:
             if self.local_repository:
                 # Copy local repository into tmp_dir.
-                rc = util.copytree(self.repository_location, self.tmp_dir)
+                rc = util.copytree(self.repository_location,
+                                   os.path.join(self.tmp_dir,
+                                                self.repository_local_name))
             else:
                 if self.repository_type == 'svn':
                     rc = util.svn_checkout(self.repository_location,


### PR DESCRIPTION
New `local-repository` option allows specification of a pre-existing local clone/checkout of a repository via `repository-location`. This local repo checkout is copied into the qiime-deploy temp dir and used as if it was checked out from a remote repository.

This was tested on an Ubuntu EC2 instance with both SVN and git repos. Fixes #24.

A corresponding pull request to qiime-deploy-conf will also be issued and should be merged if/when this pull request is merged.
