### PR TITLE
R package installation now cd's to valid directory first.

### DIFF
--- a/lib/application.py
+++ b/lib/application.py
@@ -509,6 +509,10 @@ class Application:
         return rc
 
     def _deploy_r_package(self):
+        # R requires that we're in a directory that exists because it does some
+        # shell initialization before installing the package.
+        os.chdir(self.deploy_dir)
+
         # The first command turns warnings into errors so that we can obtain a
         # nonzero return code if the download/install fails.
         cmd  = ("echo \"options(warn=2); "


### PR DESCRIPTION
This solves the random failures while installing R packages.

The issue was that after some build types (e.g. autoconf), the temporary build directory would be removed, and thus the current working directory would become invalid. This caused issues for the R package installer because it performs some shell initialization first.

Fixes #27.
