### PR TITLE
Ignore dangling symlinks in recursive copy

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -181,6 +181,19 @@ def copytree(srcDir, destDir):
     log.debug('Copying %s to %s' % (srcDir, destDir))
     try:
         shutil.copytree(srcDir, destDir)
+    except shutil.Error, e:
+        # Taken and modified from:
+        # https://mail.python.org/pipermail/python-bugs-list/2010-April/097195.html
+        for src, dst, error in e.args[0]:
+            if not os.path.islink(src):
+                return 1
+            else:
+                linkto = os.readlink(src)
+                if os.path.exists(linkto):
+                    return 1
+                else:
+                    # dangling symlink found.. ignoring..
+                    pass
     except:
         return 1
     return 0


### PR DESCRIPTION
This is necessary to fix an issue we're having with ea-utils (it ships with broken symlinks). Python 3 has a flag to ignore dangling symlinks, but this will have to do for now...
