### PR TITLE
Add RHEL6 dependency on sqlite-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ administrator to grant you sudo access, or to run these commands for you.
         
         sudo yum groupinstall -y "development tools"
 
-        sudo yum install -y ant compat-gcc-34-g77 java-1.6.0-openjdk java-1.6.0-openjdk-devel freetype freetype-devel zlib-devel mpich2 readline-devel zeromq zeromq-devel gsl gsl-devel libxslt libpng libpng-devel libgfortran mysql mysql-devel libXt libXt-devel libX11-devel mpich2 mpich2-devel libxml2 xorg-x11-server-Xorg dejavu* python-devel
+        sudo yum install -y ant compat-gcc-34-g77 java-1.6.0-openjdk java-1.6.0-openjdk-devel freetype freetype-devel zlib-devel mpich2 readline-devel zeromq zeromq-devel gsl gsl-devel libxslt libpng libpng-devel libgfortran mysql mysql-devel libXt libXt-devel libX11-devel mpich2 mpich2-devel libxml2 xorg-x11-server-Xorg dejavu* python-devel sqlite-devel
 
 ## Common usage examples
 


### PR DESCRIPTION
In order for headers to be available for pysqlite the sqlite-devel package is required; otherwise pysqlite build fails. Tested on RHEL 6.5.
